### PR TITLE
feat: [CHM-001] Add initial backend structure with configuration and …

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,2 @@
+FLASK_APP=run
+FLASK_DEBUG=False

--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,9 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+
+# custom
+backend/config.py
+env/
+**/__pycache__/

--- a/backend/.env.template
+++ b/backend/.env.template
@@ -1,0 +1,2 @@
+FLASK_APP=backend/run.py
+FLASK_DEBUG=False

--- a/backend/chordme/__init__.py
+++ b/backend/chordme/__init__.py
@@ -1,0 +1,10 @@
+from flask import Flask
+from flask_cors import CORS
+
+app = Flask(__name__)
+app.config.from_object('config')
+cors = CORS(app, resources={
+  r'/api/*': {
+    'origins': '*',
+  }
+})

--- a/backend/chordme/api.py
+++ b/backend/chordme/api.py
@@ -1,0 +1,12 @@
+from . import app
+
+
+@app.route('/api/v1/health', methods=['GET'])
+def health():
+    """
+    Health check endpoint.
+    """
+    return {
+        'status': 'ok',
+        'message': 'Service is running'
+    }, 200

--- a/backend/config.template.py
+++ b/backend/config.template.py
@@ -1,0 +1,1 @@
+SECRET_KEY='your-super-secret-key'

--- a/backend/run.py
+++ b/backend/run.py
@@ -1,0 +1,1 @@
+from chordme.api import *


### PR DESCRIPTION
This pull request introduces foundational changes to set up a Flask-based backend application, including environment variable templates, application initialization, and a basic API endpoint.

### Backend Setup and Configuration:

* `.env.template` and `backend/.env.template`: Added environment variable templates to specify the Flask application entry point (`FLASK_APP`) and disable debug mode (`FLASK_DEBUG=False`). (`[[1]](diffhunk://#diff-749e06f64632f62a0c0dfbf4c4f3850e27e94ac109aa121fabd5c29469ae88deR1-R2)`, `[[2]](diffhunk://#diff-4d4b0623914bc4d350a50587626421aef20b8b382317642331e342416f4b06baR1-R2)`)
* [`backend/config.template.py`](diffhunk://#diff-90ec713264696a5c92b8e0efa142f2b3fa094e59e8f1f24ffb2786cae8bf7395R1): Added a template configuration file with a placeholder for the `SECRET_KEY`. (`[backend/config.template.pyR1](diffhunk://#diff-90ec713264696a5c92b8e0efa142f2b3fa094e59e8f1f24ffb2786cae8bf7395R1)`)

### Flask Application Initialization:

* [`backend/chordme/__init__.py`](diffhunk://#diff-846caa813ae1fe28b818a04e80ebb6b51733ebbc39fb040424333ad58b2fd98eR1-R10): Initialized the Flask application, configured it using a separate configuration file, and enabled CORS for all origins on `/api/*` endpoints. (`[backend/chordme/__init__.pyR1-R10](diffhunk://#diff-846caa813ae1fe28b818a04e80ebb6b51733ebbc39fb040424333ad58b2fd98eR1-R10)`)

### API Endpoint:

* [`backend/chordme/api.py`](diffhunk://#diff-ff191cf911971f6373d23ed0872dd6d795fcf093f7387120547ceb52166ba9b9R1-R12): Added a health check endpoint (`/api/v1/health`) to verify service availability. The endpoint returns a JSON response with the service status. (`[backend/chordme/api.pyR1-R12](diffhunk://#diff-ff191cf911971f6373d23ed0872dd6d795fcf093f7387120547ceb52166ba9b9R1-R12)`)

### Application Entry Point:

* [`backend/run.py`](diffhunk://#diff-ede0d98e9b469779267d863d182515b97082d9c2a16d0f880cf88bfe86e3162dR1): Imported the `chordme.api` module to ensure the API routes are registered when the application starts. (`[backend/run.pyR1](diffhunk://#diff-ede0d98e9b469779267d863d182515b97082d9c2a16d0f880cf88bfe86e3162dR1)`)